### PR TITLE
Add credential process output option

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,5 @@ hyper-proxy = "0.9"
 directories = "5"
 rust-ini = { version = "0.20"}
 tracing-subscriber = "0.3"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 assume-role
 ===========
 
-A really simple program to assume an IAM Role (by calling [AssumeRole](https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRole.html)) and saving the resulting credentials back to your local [credential file](https://docs.aws.amazon.com/sdk-for-php/v3/developer-guide/guide_credentials_profiles.html) (`~/.aws/credentials` by default).
+A really simple program to assume an IAM Role (by calling [AssumeRole](https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRole.html)) and save the resulting credentials back to your local [credential file](https://docs.aws.amazon.com/sdk-for-php/v3/developer-guide/guide_credentials_profiles.html) (`~/.aws/credentials` by default). It can also output credentials in the [Process Credential Provider](https://docs.aws.amazon.com/sdkref/latest/guide/feature-process-credentials.html) format using `--credential-process`.
 
 Building
 --------
@@ -37,6 +37,7 @@ OPTIONS:
         --policy-json <policy-json>                Inline session policy JSON
     -p, --profile <profile>                        AWS Profile to use when calling assume-role
         --proxy <proxy>                            Proxy URL
+        --credential-process                       Print credentials in Process Credential Provider format instead of saving to a file
         --region <region>
             AWS Region for STS endpoint [env: AWS_DEFAULT_REGION=]  [default: us-east-1]
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -52,9 +52,24 @@ async fn main() -> Result<()> {
         .credentials()
         .with_context(|| "no credentials in response")?;
 
-    let mut credential_file = CredentialFile::load(&credential_filename)?;
-    credential_file.set_credentials(&cmdline.dest_profile, credentials);
-    credential_file.save(&credential_filename)?;
+    if cmdline.credential_process {
+        let expiration = credentials
+            .expiration()
+            .map(|e| e.to_string())
+            .unwrap_or_default();
+        let output = serde_json::json!({
+            "Version": 1,
+            "AccessKeyId": credentials.access_key_id(),
+            "SecretAccessKey": credentials.secret_access_key(),
+            "SessionToken": credentials.session_token(),
+            "Expiration": expiration,
+        });
+        println!("{}", output);
+    } else {
+        let mut credential_file = CredentialFile::load(&credential_filename)?;
+        credential_file.set_credentials(&cmdline.dest_profile, credentials);
+        credential_file.save(&credential_filename)?;
+    }
 
     Ok(())
 }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -67,6 +67,10 @@ pub struct Cmdline {
     #[structopt(name = "proxy", long)]
     pub proxy: Option<String>,
 
+    /// Print credentials in Process Credential Provider format instead of saving to a file
+    #[structopt(name = "credential-process", long)]
+    pub credential_process: bool,
+
     /// Enable verbose output
     #[structopt(short, long)]
     pub verbose: bool,


### PR DESCRIPTION
## Summary
- add serde dependencies
- expose `--credential-process` CLI flag
- output credentials in Process Credential Provider format when flag is used

------
https://chatgpt.com/codex/tasks/task_e_6860c6fdc2c08325b4d35bac7e9cab86