### PR TITLE
Make session-name optional with default

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ assume-role 0.1.0
 Adam Batkin <adam@batkin.net>
 
 USAGE:
-    assume-role --role <role> --session-name <session-name>
+    assume-role --role <role> [--session-name <session-name>]
 
 OPTIONS:
         --dest-file <dest-file>
@@ -43,11 +43,11 @@ OPTIONS:
             AWS Region for STS endpoint [env: AWS_DEFAULT_REGION=]  [default: us-east-1]
 
     -r, --role <role>                              ARN of role ot assume
-    -s, --session-name <session-name>              Session name to pass to assume-role
+    -s, --session-name <session-name>              Session name to pass to assume-role [default: assume-role-<timestamp>]
     -v, --verbose                                  Enable verbose output
     -V, --version                                  Prints version information
 ```
-Realistically, you need to pass `--role`, `--session-name` and you probably want `--dest-profile` (and possibly `--profile` or set `AWS_PROFILE`).
+Realistically, you need to pass `--role` and you probably want `--dest-profile` (and possibly `--profile` or set `AWS_PROFILE`).
 
 When `--verbose` is supplied, the tool enables additional tracing which also
 prints the underlying HTTP requests made by the AWS SDK. This can help with

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,9 +7,9 @@ use aws_sdk_sts::types::PolicyDescriptorType;
 use aws_sdk_sts::Client;
 use aws_smithy_runtime::client::http::hyper_014::HyperClientBuilder;
 use aws_smithy_types::{date_time::Format, DateTime};
+use hyper::client::HttpConnector;
 use std::fs;
 use std::time::{Duration, SystemTime};
-use hyper::client::HttpConnector;
 // use aws_smithy_runtime_api::client::behavior_version::BehaviorVersion;
 // use aws_smithy_runtime_api::client::http::HttpConnector;
 use serde::{Deserialize, Serialize};
@@ -49,8 +49,7 @@ impl CredentialProcessOutput {
 fn credentials_valid(output: &CredentialProcessOutput) -> Result<bool> {
     let expiration = DateTime::from_str(&output.Expiration, Format::DateTime)
         .context("failed to parse cached credential expiration")?;
-    let expiration = SystemTime::try_from(expiration)
-        .context("expiration time out of range")?;
+    let expiration = SystemTime::try_from(expiration).context("expiration time out of range")?;
     if let Ok(time_left) = expiration.duration_since(SystemTime::now()) {
         Ok(time_left > Duration::from_secs(300))
     } else {
@@ -192,6 +191,6 @@ fn build_assume_role_request(client: Client, cmdline: &Cmdline) -> AssumeRoleFlu
     }
 
     builder = builder.role_arn(&cmdline.role_arn);
-    builder = builder.role_session_name(&cmdline.session_name);
+    builder = builder.role_session_name(&cmdline.session_name());
     builder
 }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -2,6 +2,7 @@ use std::path::PathBuf;
 use std::str::FromStr;
 
 use anyhow::{Context, Result};
+use std::time::{SystemTime, UNIX_EPOCH};
 use structopt::clap::AppSettings;
 use structopt::StructOpt;
 
@@ -42,7 +43,7 @@ pub struct Cmdline {
 
     /// Session name to pass to assume-role
     #[structopt(name = "session-name", long, short = "s")]
-    pub session_name: String,
+    pub session_name: Option<String>,
 
     /// MFA device serial number
     #[structopt(name = "mfa-serial-number", long)]
@@ -80,6 +81,19 @@ pub struct Cmdline {
 impl Cmdline {
     pub fn parse() -> Cmdline {
         Cmdline::from_args()
+    }
+
+    pub fn session_name(&self) -> String {
+        match &self.session_name {
+            Some(name) => name.clone(),
+            None => {
+                let ts = SystemTime::now()
+                    .duration_since(UNIX_EPOCH)
+                    .unwrap_or_default()
+                    .as_secs();
+                format!("assume-role-{}", ts)
+            }
+        }
     }
 
     pub fn determine_credential_file(&self) -> Result<PathBuf> {


### PR DESCRIPTION
## Summary
- allow running `assume-role` without providing `--session-name`
- generate a default session name based on the current timestamp
- document new behaviour in the README

## Testing
- `cargo fmt -- --check`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_6861320462dc83258dad5e20b0571465